### PR TITLE
Correct syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ class UserItemResource(Resource):
      })
     def get(self, user_id):
         # Do some processing
-        return UserModel(id=1, name='somebody'}), 200  # generates json response {"id": 1, "name": "somebody"}
+        return UserModel(id=1, name='somebody'), 200  # generates json response {"id": 1, "name": "somebody"}
 
 ```
 


### PR DESCRIPTION
Correct syntax error in "Documenting API endpoints", remove extra `}` in `return UserModel(id=1, name='somebody'}), 200`.